### PR TITLE
tail byte/string compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # strings-vs-bytes
 ```bash
-BenchmarkBytesToStrings-4    	30000000	        38.6 ns/op	      32 B/op	       1 allocs/op
-BenchmarkBytesCompare-4      	300000000	         5.06 ns/op	       0 B/op	       0 allocs/op
-BenchmarkStringsCompare-4    	1000000000	         2.37 ns/op	       0 B/op	       0 allocs/op
-BenchmarkBytesContains-4     	100000000	        17.2 ns/op	       0 B/op	       0 allocs/op
-BenchmarkStringsContains-4   	100000000	        12.3 ns/op	       0 B/op	       0 allocs/op
-BenchmarkBytesIndex-4        	200000000	         8.75 ns/op	       0 B/op	       0 allocs/op
-BenchmarkStringIndex-4       	200000000	         6.83 ns/op	       0 B/op	       0 allocs/op
-BenchmarkBytesReplace-4      	20000000	        77.3 ns/op	      32 B/op	       1 allocs/op
-BenchmarkStringsReplace-4    	10000000	       137 ns/op	      64 B/op	       2 allocs/op
-BenchmarkBytesConcat-4       	50000000	        39.4 ns/op	      32 B/op	       1 allocs/op
-BenchmarkStringsConcat-4     	30000000	        51.0 ns/op	      32 B/op	       1 allocs/op
-BenchmarkStringsJoin-4       	20000000	        85.0 ns/op	      64 B/op	       2 allocs/op
-BenchmarkMapHints-4           100000000         12.3 ns/op        0 B/op         0 allocs/op
-BenchmarkMapsHints_Dont-4     100000000         22.0 ns/op        0 B/op         0 allocs/op
+BenchmarkBytesToStrings-4            	50000000	        20.5 ns/op	      32 B/op	       1 allocs/op
+BenchmarkBytesCompareSame-4          	300000000	         4.44 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBytesCompareDifferent-4     	300000000	         4.57 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStringsCompareSame-4        	2000000000	         1.67 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStringsCompareDifferent-4   	200000000	         8.19 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBytesContains-4             	100000000	        11.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStringsContains-4           	100000000	        10.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBytesIndex-4                	200000000	         7.11 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStringIndex-4               	300000000	         6.09 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBytesReplace-4              	20000000	        60.1 ns/op	      32 B/op	       1 allocs/op
+BenchmarkStringsReplace-4            	20000000	        91.4 ns/op	      64 B/op	       2 allocs/op
+BenchmarkBytesConcat2-4              	50000000	        23.9 ns/op	      32 B/op	       1 allocs/op
+BenchmarkStringsConcat2-4            	50000000	        37.4 ns/op	      32 B/op	       1 allocs/op
+BenchmarkStringsJoin2-4              	30000000	        48.5 ns/op	      32 B/op	       1 allocs/op
+BenchmarkMapHints-4                  	200000000	         7.08 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMapsHints_Dont-4            	100000000	        12.2 ns/op	       0 B/op	       0 allocs/op
 ```
 
 ### Link :

--- a/bench_test.go
+++ b/bench_test.go
@@ -24,9 +24,9 @@ func BenchmarkBytesToStrings(b *testing.B) {
 	result = r
 }
 
-//BenchmarkBytesCompare compare 2 []bytes.
+//BenchmarkBytesCompareSame compare 2 []bytes.
 //https://golang.org/pkg/bytes/#Compare
-func BenchmarkBytesCompare(b *testing.B) {
+func BenchmarkBytesCompareSame(b *testing.B) {
 
 	s1 := []byte("string to compare")
 	s2 := []byte("string to compare")
@@ -41,12 +41,46 @@ func BenchmarkBytesCompare(b *testing.B) {
 	result = r
 }
 
-//BenchmarkStringsCompare compare 2 strings.
+//BenchmarkBytesCompareDifferent compare 2 []bytes.
+//https://golang.org/pkg/bytes/#Compare
+func BenchmarkBytesCompareDifferent(b *testing.B) {
+
+	s1 := []byte("string to compare A")
+	s2 := []byte("string to compare B")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var r int
+	for n := 0; n < b.N; n++ {
+		r = bytes.Compare(s1, s2)
+	}
+
+	result = r
+}
+
+//BenchmarkStringsCompareSame compare 2 strings.
 //https://golang.org/pkg/strings/#Compare
-func BenchmarkStringsCompare(b *testing.B) {
+func BenchmarkStringsCompareSame(b *testing.B) {
 
 	s1 := "string to compare"
 	s2 := "string to compare"
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var r int
+	for n := 0; n < b.N; n++ {
+		r = strings.Compare(s1, s2)
+	}
+
+	result = r
+}
+
+//BenchmarkStringsCompareDifferent compare 2 strings.
+//https://golang.org/pkg/strings/#Compare
+func BenchmarkStringsCompareDifferent(b *testing.B) {
+
+	s1 := "string to compare A"
+	s2 := "string to compare B"
 
 	b.ResetTimer()
 	b.ReportAllocs()


### PR DESCRIPTION
An illustration that byte compare is stable while string compare depends on the nature of the string.